### PR TITLE
use translucent top bar to better fit the material theme

### DIFF
--- a/gnome-shell/_colors.scss
+++ b/gnome-shell/_colors.scss
@@ -27,7 +27,7 @@ $base_color: #455A64;
 $fill_color: scale-color($fg_color, $alpha: -85%);
 $semi_fill_color: scale-color($fg_color, $alpha: -93%);
 
-$panel_bg_color: #000000;
+$panel_bg_color: rgba(0,0,0,0.6);
 
 $selected_bg_color: #00BCD4;
 
@@ -95,4 +95,3 @@ $backdrop_insensitive_color: if($variant =='light', darken($backdrop_bg_color,15
 
 $backdrop_borders_color: $borders_color;
 $backdrop_dark_fill: mix($backdrop_borders_color,$backdrop_bg_color, 35%);
-


### PR DESCRIPTION
As title states, it looks much better with the theme than plain black. It's not entirely transparent to make it visible on bright wallpapers. 