### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_INIT(
 	[Adapta ],
-	3.20.2,
+	3.20.3,
 	[https://github.com/tista500/Adapta],
 	[adapta-gtk-theme]
 )


### PR DESCRIPTION
GTK 3.20.3 now available - https://download.gnome.org/sources/gtk+/3.20/gtk+-3.20.3.tar.xz