### PR TITLE
Update App Overview icon in Dash to Android Marshmallow style

### DIFF
--- a/gnome-shell/assets/show-apps-active.svg
+++ b/gnome-shell/assets/show-apps-active.svg
@@ -1,80 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64"
-   height="64"
-   viewBox="0 0 64 64"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="show-apps-active.svg"
-   style="stroke:#ffffff">
-  <metadata
-     id="metadata16">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs14" />
-  <sodipodi:namedview
-     pagecolor="#808080"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="734"
-     id="namedview12"
-     showgrid="true"
-     inkscape:zoom="6.2105263"
-     inkscape:cx="35.350574"
-     inkscape:cy="37.078029"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2"
-     showguides="false">
-    <sodipodi:guide
-       position="590.23042,546.50965"
-       orientation="0,1"
-       id="guide4136" />
-    <inkscape:grid
-       type="xygrid"
-       id="grid4162" />
-  </sodipodi:namedview>
-  <g
-     style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.89110084;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="g6"
-     transform="matrix(0,-1.4515384,1.4515326,0,5.872689,58.127843)">
-    <circle
-       style="stroke:#ffffff;stroke-width:1.89110084;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="circle8"
-       r="18"
-       cy="18"
-       cx="18" />
-  </g>
-  <path
-     inkscape:connector-curvature="0"
-     d="m 28.235411,41.494255 7.529777,0 0,-7.595264 -7.529777,0 z m -11.294665,0 7.529777,0 0,-7.595264 -7.529777,0 z m 0,-11.392896 7.529777,0 0,-7.595264 -7.529777,0 z m 11.294665,0 7.529777,0 0,-7.595264 -7.529777,0 z m 11.294665,0 7.529777,0 0,-7.595264 -7.529777,0 z m 0,11.392896 7.529777,0 0,-7.595264 -7.529777,0 z"
-     id="path4"
-     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.72727269;stroke-opacity:0.75"
-     sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
+<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="64" width="64" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" viewBox="0 0 64.000783 64.00078">
+ <title>App Drawer Marshmallow</title>
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title>App Drawer Marshmallow</dc:title>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>HEXcube</dc:title>
+     </cc:Agent>
+    </dc:creator>
+    <dc:source>https://android.googlesource.com/platform/packages/apps/Launcher3/+/marshmallow-release/res/drawable-xxhdpi/ic_allapps.png</dc:source>
+    <dc:description>Android Marshmallow&apos;s App Drawer button recreated as vector SVG</dc:description>
+    <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <filter id="filter4178" style="color-interpolation-filters:sRGB">
+   <feFlood result="flood" flood-opacity=".49804" flood-color="rgb(51,51,51)"/>
+   <feComposite operator="in" result="composite1" in2="SourceGraphic" in="flood"/>
+   <feGaussianBlur stdDeviation="1" result="blur" in="composite1"/>
+   <feOffset result="offset" dx="1" dy="1"/>
+   <feComposite operator="over" result="composite2" in2="offset" in="SourceGraphic"/>
+  </filter>
+ </defs>
+ <path d="m32 7a25 25 0 0 0 -25 25 25 25 0 0 0 25 25 25 25 0 0 0 25 -25 25 25 0 0 0 -25 -25zm-11 17a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm11 0a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm11 0a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm-22 11a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm11 0a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm11 0a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5z" filter="url(#filter4178)" fill="#fff"/>
 </svg>

--- a/gnome-shell/assets/show-apps.svg
+++ b/gnome-shell/assets/show-apps.svg
@@ -1,84 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64"
-   height="64"
-   viewBox="0 0 64 64"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="show-apps.svg"
-   style="stroke:#ffffff">
-  <metadata
-     id="metadata16">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs14" />
-  <sodipodi:namedview
-     pagecolor="#808080"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="734"
-     id="namedview12"
-     showgrid="true"
-     inkscape:zoom="6.2105263"
-     inkscape:cx="32.130235"
-     inkscape:cy="37.078029"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2"
-     showguides="false">
-    <sodipodi:guide
-       position="590.23042,546.50965"
-       orientation="0,1"
-       id="guide4136" />
-    <inkscape:grid
-       type="xygrid"
-       id="grid4162" />
-  </sodipodi:namedview>
-  <g
-     id="g4137"
-     transform="matrix(1.3095264,0,0,1.3095283,0.57166599,0.57149573)">
-    <g
-       transform="matrix(0,-1.1084437,1.1084409,0,4.0480459,43.951969)"
-       id="g6"
-       style="fill:none;fill-rule:evenodd;stroke:#eceff1;stroke-width:1.8909955;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74901961">
-      <circle
-         cx="18"
-         cy="18"
-         r="18"
-         id="circle8"
-         style="stroke:#eceff1;stroke-width:1.8909955;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74901961" />
-    </g>
-    <path
-       sodipodi:nodetypes="cccccccccccccccccccccccccccccc"
-       style="fill:#eceff1;fill-opacity:0.74901961;stroke:none;stroke-width:0.72727269;stroke-opacity:0.75"
-       id="path4"
-       d="m 21.125,31.25 5.75,0 0,-5.8 -5.75,0 z m -8.625,0 5.75,0 0,-5.8 -5.75,0 z m 0,-8.7 5.75,0 0,-5.8 -5.75,0 z m 8.625,0 5.75,0 0,-5.8 -5.75,0 z m 8.625,0 5.75,0 0,-5.8 -5.75,0 z m 0,8.7 5.75,0 0,-5.8 -5.75,0 z"
-       inkscape:connector-curvature="0" />
-  </g>
+<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="64" width="64" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" viewBox="0 0 64.000783 64.00078">
+ <title>App Drawer Marshmallow</title>
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title>App Drawer Marshmallow</dc:title>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>HEXcube</dc:title>
+     </cc:Agent>
+    </dc:creator>
+    <dc:source>https://android.googlesource.com/platform/packages/apps/Launcher3/+/marshmallow-release/res/drawable-xxhdpi/ic_allapps.png</dc:source>
+    <dc:description>Android Marshmallow&apos;s App Drawer button recreated as vector SVG</dc:description>
+    <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <filter id="filter4178" style="color-interpolation-filters:sRGB">
+   <feFlood result="flood" flood-opacity=".49804" flood-color="rgb(51,51,51)"/>
+   <feComposite operator="in" result="composite1" in2="SourceGraphic" in="flood"/>
+   <feGaussianBlur stdDeviation="1" result="blur" in="composite1"/>
+   <feOffset result="offset" dx="1" dy="1"/>
+   <feComposite operator="over" result="composite2" in2="offset" in="SourceGraphic"/>
+  </filter>
+ </defs>
+ <path d="m32 7a25 25 0 0 0 -25 25 25 25 0 0 0 25 25 25 25 0 0 0 25 -25 25 25 0 0 0 -25 -25zm-11 17a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm11 0a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm11 0a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm-22 11a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm11 0a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5zm11 0a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 -2.5 2.5 2.5 2.5 0 0 1 -2.5 -2.5 2.5 2.5 0 0 1 2.5 -2.5z" filter="url(#filter4178)" fill="#ececec"/>
 </svg>


### PR DESCRIPTION
- SVG icon recreated from Marshmallow's original icon: https://android.googlesource.com/platform/packages/apps/Launcher3/+/marshmallow-release/res/drawable-xxhdpi/ic_allapps.png