### PR TITLE
Typo _common.scss [gtk-3.20]

### DIFF
--- a/gtk/sass/3.20/_common.scss
+++ b/gtk/sass/3.20/_common.scss
@@ -2188,7 +2188,7 @@ headerbar,
 // force using rounded corners in case of paned titlebars
 window:not(.maximized):not(.tiled) {
   paned.titlebar,
-  gtid.titlebar {
+  grid.titlebar {
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
 


### PR DESCRIPTION
Typo in /gtk/sass/3.20/_common.scss
line 2191: gtid.titlebar --> grid.titlebar (cfr. 3.22)

Fixes https://github.com/tista500/Adapta/issues/196